### PR TITLE
Add SwiftUI piano keyboard with simple audio engine

### DIFF
--- a/Simple Keys/ContentView.swift
+++ b/Simple Keys/ContentView.swift
@@ -7,44 +7,157 @@
 
 import SwiftUI
 
+struct PianoKey: Identifiable {
+    let id: String
+    let displayName: String
+    let frequency: Double
+    let positionMultiplier: CGFloat?
+
+    init(displayName: String, frequency: Double, positionMultiplier: CGFloat? = nil) {
+        self.id = displayName
+        self.displayName = displayName
+        self.frequency = frequency
+        self.positionMultiplier = positionMultiplier
+    }
+}
+
 struct ContentView: View {
-    let offset: CGFloat = 8
-    
+    private let whiteKeys: [PianoKey] = [
+        PianoKey(displayName: "C", frequency: 261.63),
+        PianoKey(displayName: "D", frequency: 293.66),
+        PianoKey(displayName: "E", frequency: 329.63),
+        PianoKey(displayName: "F", frequency: 349.23),
+        PianoKey(displayName: "G", frequency: 392.00),
+        PianoKey(displayName: "A", frequency: 440.00),
+        PianoKey(displayName: "B", frequency: 493.88)
+    ]
+
+    private let blackKeys: [PianoKey] = [
+        PianoKey(displayName: "C♯", frequency: 277.18, positionMultiplier: 0.95),
+        PianoKey(displayName: "D♯", frequency: 311.13, positionMultiplier: 1.95),
+        PianoKey(displayName: "F♯", frequency: 369.99, positionMultiplier: 3.95),
+        PianoKey(displayName: "G♯", frequency: 415.30, positionMultiplier: 4.95),
+        PianoKey(displayName: "A♯", frequency: 466.16, positionMultiplier: 5.95)
+    ]
+
+    private let backgroundGradient = LinearGradient(colors: [
+        Color(red: 0.96, green: 0.97, blue: 0.99),
+        Color(red: 0.89, green: 0.92, blue: 0.97)
+    ], startPoint: .top, endPoint: .bottom)
+
     var body: some View {
-        VStack(spacing: 0) {
-            
-            //rectangles are keys
-            HStack(spacing: 8) {
-                Spacer()
-                    .frame(width: 64)
-                Rectangle()
-                    .foregroundStyle(.black.opacity(0.88))
-                Rectangle()
-                    .foregroundStyle(.black.opacity(0.88))
-                Spacer()
-                    .frame(width: 64)
+        GeometryReader { geometry in
+            let size = geometry.size
+            let isLandscape = size.width > size.height
+            let horizontalPadding = size.width * (isLandscape ? 0.05 : 0.08)
+            let availableWidth = max(size.width - (horizontalPadding * 2), size.width * 0.7)
+            let whiteKeyWidth = availableWidth / CGFloat(whiteKeys.count)
+            let preferredHeight = whiteKeyWidth * (isLandscape ? 4.0 : 5.0)
+            let whiteKeyHeight = min(size.height * 0.9, preferredHeight)
+            let blackKeyWidth = whiteKeyWidth * 0.6
+            let blackKeyHeight = whiteKeyHeight * 0.6
+
+            ZStack {
+                backgroundGradient
+                    .ignoresSafeArea()
+
+                VStack {
+                    Spacer()
+
+                    ZStack(alignment: .topLeading) {
+                        whiteKeyStack(width: whiteKeyWidth, height: whiteKeyHeight)
+
+                        blackKeyStack(
+                            whiteKeyWidth: whiteKeyWidth,
+                            blackKeyWidth: blackKeyWidth,
+                            blackKeyHeight: blackKeyHeight
+                        )
+                        .padding(.top, whiteKeyHeight * 0.02)
+                    }
+                    .frame(width: availableWidth, height: whiteKeyHeight, alignment: .topLeading)
+                    .padding(.horizontal, horizontalPadding)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel("Piano keyboard")
+
+                    Spacer()
+                }
             }
-            
-            //spaces are keys
-            HStack(spacing: 16) {
-                Spacer()
-                    .frame(width: 120 - offset)
-                Rectangle()
-                    .foregroundStyle(.black.opacity(0.88))
-                Spacer()
-                    .frame(width: 88 + offset)
-                Rectangle()
-                    .foregroundStyle(.black.opacity(0.88))
-                Spacer()
-                    .frame(width: 120 - offset)
+            .onAppear {
+                _ = PianoSoundEngine.shared
             }
-                .frame(height: 256)
         }
-        .background{
-            Color.black.opacity(0.08)
+    }
+
+    private func whiteKeyStack(width: CGFloat, height: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            ForEach(whiteKeys) { key in
+                Button {
+                    PianoSoundEngine.shared.play(frequency: key.frequency)
+                } label: {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.white)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.black.opacity(0.12), lineWidth: 1)
+                        )
+                        .overlay(alignment: .bottom) {
+                            Text(key.displayName)
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(Color.black.opacity(0.7))
+                                .padding(.bottom, 10)
+                        }
+                }
+                .buttonStyle(.plain)
+                .frame(width: width, height: height, alignment: .bottom)
+                .accessibilityLabel("\(key.displayName) note")
+            }
         }
-        .ignoresSafeArea()
-        
+    }
+
+    private func blackKeyStack(whiteKeyWidth: CGFloat, blackKeyWidth: CGFloat, blackKeyHeight: CGFloat) -> some View {
+        ZStack(alignment: .topLeading) {
+            ForEach(blackKeys) { key in
+                if let position = key.positionMultiplier {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.black)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                        )
+                        .overlay(alignment: .bottom) {
+                            Text(key.displayName)
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(Color.white.opacity(0.85))
+                                .padding(.bottom, 8)
+                        }
+                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 6)
+                        .frame(width: blackKeyWidth, height: blackKeyHeight, alignment: .bottom)
+                        .position(
+                            x: whiteKeyWidth * position,
+                            y: blackKeyHeight / 2
+                        )
+                }
+            }
+
+            ForEach(blackKeys) { key in
+                if let position = key.positionMultiplier {
+                    Button {
+                        PianoSoundEngine.shared.play(frequency: key.frequency)
+                    } label: {
+                        Color.clear
+                    }
+                    .frame(width: blackKeyWidth, height: blackKeyHeight)
+                    .contentShape(RoundedRectangle(cornerRadius: 6))
+                    .position(
+                        x: whiteKeyWidth * position,
+                        y: blackKeyHeight / 2
+                    )
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(key.displayName) sharp note")
+                }
+            }
+        }
     }
 }
 

--- a/Simple Keys/PianoSoundEngine.swift
+++ b/Simple Keys/PianoSoundEngine.swift
@@ -1,0 +1,73 @@
+import AVFoundation
+
+final class PianoSoundEngine {
+    static let shared = PianoSoundEngine()
+
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let format: AVAudioFormat
+    private let sampleRate: Double
+
+    private init() {
+        format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1)!
+        sampleRate = format.sampleRate
+
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+
+        let session = AVAudioSession.sharedInstance()
+
+        do {
+            try session.setCategory(.ambient, options: [.mixWithOthers])
+            try session.setActive(true)
+        } catch {
+            print("Audio session setup failed: \(error.localizedDescription)")
+        }
+
+        do {
+            try engine.start()
+        } catch {
+            print("Audio engine failed to start: \(error.localizedDescription)")
+        }
+    }
+
+    func play(frequency: Double) {
+        let buffer = makeBuffer(frequency: frequency)
+        player.scheduleBuffer(buffer, at: nil, options: [.interrupts], completionHandler: nil)
+
+        if !player.isPlaying {
+            player.play()
+        }
+    }
+
+    private func makeBuffer(frequency: Double) -> AVAudioPCMBuffer {
+        let duration: Double = 0.7
+        let frameCount = AVAudioFrameCount(sampleRate * duration)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            fatalError("Unable to allocate audio buffer")
+        }
+
+        buffer.frameLength = frameCount
+
+        let attackSamples = Int(sampleRate * 0.02)
+        let releaseSamples = Int(sampleRate * 0.15)
+        let releaseStart = max(0, Int(frameCount) - releaseSamples)
+
+        let amplitude: Float = 0.25
+        let channel = buffer.floatChannelData![0]
+        for sampleIndex in 0..<Int(frameCount) {
+            let phase = 2.0 * Double.pi * Double(sampleIndex) * frequency / sampleRate
+            var envelope: Float = 1.0
+
+            if sampleIndex < attackSamples {
+                envelope = Float(sampleIndex) / Float(attackSamples)
+            } else if sampleIndex > releaseStart {
+                envelope = Float(Int(frameCount) - sampleIndex) / Float(releaseSamples)
+            }
+
+            channel[sampleIndex] = Float(sin(phase)) * amplitude * envelope
+        }
+
+        return buffer
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder layout with a responsive SwiftUI piano keyboard that fits a full octave in landscape
- synthesize sine wave tones for each key press through a lightweight audio engine and initialize it on view load

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de1fce8e54832889c2de2728152d73