### PR TITLE
Restore minimal keyboard layout and enhance audio

### DIFF
--- a/Simple Keys/ContentView.swift
+++ b/Simple Keys/ContentView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PianoKey: Identifiable {
+struct PianoKey: Identifiable, Equatable {
     let id: String
     let displayName: String
     let frequency: Double
@@ -22,7 +22,18 @@ struct PianoKey: Identifiable {
 }
 
 struct ContentView: View {
-    private let whiteKeys: [PianoKey] = [
+    private let portraitWhiteKeys: [PianoKey] = [
+        PianoKey(displayName: "C", frequency: 261.63),
+        PianoKey(displayName: "D", frequency: 293.66),
+        PianoKey(displayName: "E", frequency: 329.63)
+    ]
+
+    private let portraitBlackKeys: [PianoKey] = [
+        PianoKey(displayName: "C♯", frequency: 277.18, positionMultiplier: 0.95),
+        PianoKey(displayName: "D♯", frequency: 311.13, positionMultiplier: 1.95)
+    ]
+
+    private let landscapeWhiteKeys: [PianoKey] = [
         PianoKey(displayName: "C", frequency: 261.63),
         PianoKey(displayName: "D", frequency: 293.66),
         PianoKey(displayName: "E", frequency: 329.63),
@@ -32,7 +43,7 @@ struct ContentView: View {
         PianoKey(displayName: "B", frequency: 493.88)
     ]
 
-    private let blackKeys: [PianoKey] = [
+    private let landscapeBlackKeys: [PianoKey] = [
         PianoKey(displayName: "C♯", frequency: 277.18, positionMultiplier: 0.95),
         PianoKey(displayName: "D♯", frequency: 311.13, positionMultiplier: 1.95),
         PianoKey(displayName: "F♯", frequency: 369.99, positionMultiplier: 3.95),
@@ -40,39 +51,44 @@ struct ContentView: View {
         PianoKey(displayName: "A♯", frequency: 466.16, positionMultiplier: 5.95)
     ]
 
-    private let backgroundGradient = LinearGradient(colors: [
-        Color(red: 0.96, green: 0.97, blue: 0.99),
-        Color(red: 0.89, green: 0.92, blue: 0.97)
-    ], startPoint: .top, endPoint: .bottom)
+    private let backgroundColor = Color(red: 0.91, green: 0.92, blue: 0.94)
 
     var body: some View {
         GeometryReader { geometry in
             let size = geometry.size
             let isLandscape = size.width > size.height
-            let horizontalPadding = size.width * (isLandscape ? 0.05 : 0.08)
-            let availableWidth = max(size.width - (horizontalPadding * 2), size.width * 0.7)
+            let whiteKeys = isLandscape ? landscapeWhiteKeys : portraitWhiteKeys
+            let blackKeys = isLandscape ? landscapeBlackKeys : portraitBlackKeys
+            let horizontalPadding = size.width * (isLandscape ? 0.05 : 0.16)
+            let availableWidth = size.width - (horizontalPadding * 2)
             let whiteKeyWidth = availableWidth / CGFloat(whiteKeys.count)
-            let preferredHeight = whiteKeyWidth * (isLandscape ? 4.0 : 5.0)
-            let whiteKeyHeight = min(size.height * 0.9, preferredHeight)
-            let blackKeyWidth = whiteKeyWidth * 0.6
-            let blackKeyHeight = whiteKeyHeight * 0.6
+            let whiteKeyHeight = min(size.height * (isLandscape ? 0.7 : 0.78), whiteKeyWidth * (isLandscape ? 3.2 : 4.6))
+            let blackKeyWidth = whiteKeyWidth * (isLandscape ? 0.58 : 0.64)
+            let blackKeyHeight = isLandscape ? whiteKeyHeight * 0.62 : whiteKeyHeight
 
             ZStack {
-                backgroundGradient
+                backgroundColor
                     .ignoresSafeArea()
 
                 VStack {
                     Spacer()
 
                     ZStack(alignment: .topLeading) {
-                        whiteKeyStack(width: whiteKeyWidth, height: whiteKeyHeight)
+                        whiteKeyStack(
+                            keys: whiteKeys,
+                            keyWidth: whiteKeyWidth,
+                            keyHeight: whiteKeyHeight,
+                            isLandscape: isLandscape
+                        )
 
                         blackKeyStack(
+                            keys: blackKeys,
                             whiteKeyWidth: whiteKeyWidth,
                             blackKeyWidth: blackKeyWidth,
-                            blackKeyHeight: blackKeyHeight
+                            blackKeyHeight: blackKeyHeight,
+                            isLandscape: isLandscape
                         )
-                        .padding(.top, whiteKeyHeight * 0.02)
+                        .padding(.top, isLandscape ? whiteKeyHeight * 0.02 : 0)
                     }
                     .frame(width: availableWidth, height: whiteKeyHeight, alignment: .topLeading)
                     .padding(.horizontal, horizontalPadding)
@@ -88,72 +104,60 @@ struct ContentView: View {
         }
     }
 
-    private func whiteKeyStack(width: CGFloat, height: CGFloat) -> some View {
+    private func whiteKeyStack(keys: [PianoKey], keyWidth: CGFloat, keyHeight: CGFloat, isLandscape: Bool) -> some View {
         HStack(spacing: 0) {
-            ForEach(whiteKeys) { key in
+            ForEach(Array(keys.enumerated()), id: \.element.id) { index, key in
                 Button {
                     PianoSoundEngine.shared.play(frequency: key.frequency)
                 } label: {
-                    RoundedRectangle(cornerRadius: 10)
+                    Rectangle()
                         .fill(Color.white)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color.black.opacity(0.12), lineWidth: 1)
-                        )
-                        .overlay(alignment: .bottom) {
-                            Text(key.displayName)
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                                .foregroundStyle(Color.black.opacity(0.7))
-                                .padding(.bottom, 10)
+                        .overlay(alignment: .leading) {
+                            if index != 0 {
+                                Rectangle()
+                                    .fill(Color.black)
+                                    .frame(width: isLandscape ? 1 : 3)
+                            }
+                        }
+                        .overlay(alignment: .trailing) {
+                            if index != keys.count - 1 {
+                                Rectangle()
+                                    .fill(Color.black)
+                                    .frame(width: isLandscape ? 1 : 3)
+                            }
                         }
                 }
                 .buttonStyle(.plain)
-                .frame(width: width, height: height, alignment: .bottom)
+                .frame(width: keyWidth, height: keyHeight)
+                .contentShape(Rectangle())
                 .accessibilityLabel("\(key.displayName) note")
             }
         }
     }
 
-    private func blackKeyStack(whiteKeyWidth: CGFloat, blackKeyWidth: CGFloat, blackKeyHeight: CGFloat) -> some View {
+    private func blackKeyStack(
+        keys: [PianoKey],
+        whiteKeyWidth: CGFloat,
+        blackKeyWidth: CGFloat,
+        blackKeyHeight: CGFloat,
+        isLandscape: Bool
+    ) -> some View {
         ZStack(alignment: .topLeading) {
-            ForEach(blackKeys) { key in
-                if let position = key.positionMultiplier {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.black)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .stroke(Color.white.opacity(0.12), lineWidth: 1)
-                        )
-                        .overlay(alignment: .bottom) {
-                            Text(key.displayName)
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(Color.white.opacity(0.85))
-                                .padding(.bottom, 8)
-                        }
-                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 6)
-                        .frame(width: blackKeyWidth, height: blackKeyHeight, alignment: .bottom)
-                        .position(
-                            x: whiteKeyWidth * position,
-                            y: blackKeyHeight / 2
-                        )
-                }
-            }
-
-            ForEach(blackKeys) { key in
+            ForEach(keys) { key in
                 if let position = key.positionMultiplier {
                     Button {
                         PianoSoundEngine.shared.play(frequency: key.frequency)
                     } label: {
-                        Color.clear
+                        RoundedRectangle(cornerRadius: isLandscape ? 6 : 0)
+                            .fill(Color.black)
                     }
+                    .buttonStyle(.plain)
                     .frame(width: blackKeyWidth, height: blackKeyHeight)
-                    .contentShape(RoundedRectangle(cornerRadius: 6))
+                    .contentShape(RoundedRectangle(cornerRadius: isLandscape ? 6 : 0))
                     .position(
                         x: whiteKeyWidth * position,
                         y: blackKeyHeight / 2
                     )
-                    .buttonStyle(.plain)
                     .accessibilityLabel("\(key.displayName) sharp note")
                 }
             }

--- a/Simple Keys/PianoSoundEngine.swift
+++ b/Simple Keys/PianoSoundEngine.swift
@@ -4,7 +4,10 @@ final class PianoSoundEngine {
     static let shared = PianoSoundEngine()
 
     private let engine = AVAudioEngine()
-    private let player = AVAudioPlayerNode()
+    private var players: [AVAudioPlayerNode] = []
+    private var playerAvailability: [Bool] = []
+    private var nextPlayerIndex: Int = 0
+    private let playerQueue = DispatchQueue(label: "PianoSoundEngine.queue")
     private let format: AVAudioFormat
     private let sampleRate: Double
 
@@ -12,8 +15,13 @@ final class PianoSoundEngine {
         format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1)!
         sampleRate = format.sampleRate
 
-        engine.attach(player)
-        engine.connect(player, to: engine.mainMixerNode, format: format)
+        for _ in 0..<5 {
+            let player = AVAudioPlayerNode()
+            players.append(player)
+            playerAvailability.append(false)
+            engine.attach(player)
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+        }
 
         let session = AVAudioSession.sharedInstance()
 
@@ -33,15 +41,41 @@ final class PianoSoundEngine {
 
     func play(frequency: Double) {
         let buffer = makeBuffer(frequency: frequency)
-        player.scheduleBuffer(buffer, at: nil, options: [.interrupts], completionHandler: nil)
 
-        if !player.isPlaying {
-            player.play()
+        playerQueue.async {
+            let playerIndex = self.nextAvailablePlayerIndex()
+            let player = self.players[playerIndex]
+
+            if self.playerAvailability[playerIndex] {
+                player.stop()
+            }
+
+            self.playerAvailability[playerIndex] = true
+
+            player.scheduleBuffer(buffer, at: nil, options: []) { [weak self] in
+                self?.playerQueue.async {
+                    self?.playerAvailability[playerIndex] = false
+                }
+            }
+
+            if !player.isPlaying {
+                player.play()
+            }
         }
     }
 
+    private func nextAvailablePlayerIndex() -> Int {
+        if let availableIndex = playerAvailability.firstIndex(of: false) {
+            return availableIndex
+        }
+
+        let index = nextPlayerIndex
+        nextPlayerIndex = (nextPlayerIndex + 1) % players.count
+        return index
+    }
+
     private func makeBuffer(frequency: Double) -> AVAudioPCMBuffer {
-        let duration: Double = 0.7
+        let duration: Double = 1.2
         let frameCount = AVAudioFrameCount(sampleRate * duration)
         guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
             fatalError("Unable to allocate audio buffer")
@@ -49,20 +83,22 @@ final class PianoSoundEngine {
 
         buffer.frameLength = frameCount
 
-        let attackSamples = Int(sampleRate * 0.02)
-        let releaseSamples = Int(sampleRate * 0.15)
-        let releaseStart = max(0, Int(frameCount) - releaseSamples)
-
-        let amplitude: Float = 0.25
+        let attackSamples = max(1, Int(sampleRate * 0.008))
+        let sustainStart = attackSamples
+        let totalSamples = Int(frameCount)
+        let amplitude: Float = 0.32
         let channel = buffer.floatChannelData![0]
-        for sampleIndex in 0..<Int(frameCount) {
+
+        for sampleIndex in 0..<totalSamples {
             let phase = 2.0 * Double.pi * Double(sampleIndex) * frequency / sampleRate
             var envelope: Float = 1.0
 
             if sampleIndex < attackSamples {
-                envelope = Float(sampleIndex) / Float(attackSamples)
-            } else if sampleIndex > releaseStart {
-                envelope = Float(Int(frameCount) - sampleIndex) / Float(releaseSamples)
+                let progress = Float(sampleIndex) / Float(max(attackSamples, 1))
+                envelope = pow(progress, 0.3)
+            } else {
+                let decayProgress = Float(sampleIndex - sustainStart) / Float(max(totalSamples - sustainStart, 1))
+                envelope = exp(-decayProgress * 2.4)
             }
 
             channel[sampleIndex] = Float(sin(phase)) * amplitude * envelope


### PR DESCRIPTION
## Summary
- restore the minimalist portrait keyboard layout with three white keys and support a full octave in landscape
- ensure black keys are tappable in both orientations while keeping the minimal styling
- refactor the sound engine for five-note polyphony and add an exponential decay envelope with a tight attack and 1.2s tail

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de268ce0388328a9bfdd530b7c8b07